### PR TITLE
Demo bugs

### DIFF
--- a/demo/demo.py
+++ b/demo/demo.py
@@ -124,7 +124,7 @@ if __name__ == "__main__":
                 if len(args.input) == 1:
                     for k in visualized_output.keys():
                         os.makedirs(k, exist_ok=True)
-                        out_filename = os.path.join(k, args.output)
+                        out_filename = os.path.join(args.output, k)
                         visualized_output[k].save(out_filename)    
                 else:
                     for k in visualized_output.keys():

--- a/demo/visualizer.py
+++ b/demo/visualizer.py
@@ -224,7 +224,7 @@ class _PanopticPrediction:
         assert (
             len(empty_ids) == 1
         ), ">1 ids corresponds to no labels. This is currently not supported"
-        return (self._seg != empty_ids[0]).numpy().astype(np.bool)
+        return (self._seg != empty_ids[0]).numpy().astype(bool)
 
     def semantic_masks(self):
         for sid in self._seg_ids:
@@ -232,14 +232,14 @@ class _PanopticPrediction:
             if sinfo is None or sinfo["isthing"]:
                 # Some pixels (e.g. id 0 in PanopticFPN) have no instance or semantic predictions.
                 continue
-            yield (self._seg == sid).numpy().astype(np.bool), sinfo
+            yield (self._seg == sid).numpy().astype(bool), sinfo
 
     def instance_masks(self):
         for sid in self._seg_ids:
             sinfo = self._sinfo.get(sid)
             if sinfo is None or not sinfo["isthing"]:
                 continue
-            mask = (self._seg == sid).numpy().astype(np.bool)
+            mask = (self._seg == sid).numpy().astype(bool)
             if mask.sum() > 0:
                 yield mask, sinfo
 

--- a/demo/visualizer.py
+++ b/demo/visualizer.py
@@ -966,6 +966,7 @@ class Visualizer:
             font_size = self._default_font_size
 
         # since the text background is dark, we don't want the text to be dark
+        color = tuple(np.clip(color, a_min=0, a_max=1))
         color = np.maximum(list(mplc.to_rgb(color)), 0.2)
         color[np.argmax(color)] = max(0.8, np.max(color))
 


### PR DESCRIPTION
This PR enables running OneFormer demo for one image, and to remove the [deprecated](https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated) np.bool